### PR TITLE
Fix: file-opener plugin is causing cordova build to fail

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,17 +26,11 @@
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
         </config-file>
-        <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
-          <provider tools:replace="android:authorities" android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.opener.provider" android:exported="false" android:grantUriPermissions="true">
-            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/opener_paths" />
-          </provider>
-          <provider tools:replace="android:authorities" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true" android:name="android.support.v4.content.FileProvider">
-            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/opener_paths" />
-          </provider>
+	<config-file target="app/src/main/AndroidManifest.xml" parent="/manifest/application">
+	    <provider android:name="io.github.pwlin.cordova.plugins.fileopener2.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">
+		<meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/opener_paths" />
+	    </provider>
         </config-file>
-        <edit-config file="app/src/main/AndroidManifest.xml" target="/manifest" mode="merge">
-            <manifest xmlns:tools="http://schemas.android.com/tools" />
-        </edit-config>
         <source-file src="src/android/res/xml/opener_paths.xml" target-dir="res/xml" />
         <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>


### PR DESCRIPTION
When https://github.com/wavemaker/cordova-dialog-gps plugin is added to cordova, cordova is failing due to conflict between this plugin and gps plugin. So, removed the unnecessary conflicting part in this plugin.